### PR TITLE
Bugfix - Infinite StartRecord retry loop causing level load hang

### DIFF
--- a/Objects/Handler.cs
+++ b/Objects/Handler.cs
@@ -59,6 +59,7 @@ namespace NeonCapture.Objects
             Stopping
         }
         RecordStatus recordStatus = RecordStatus.Stopped;
+        bool nudgeSent = false;
 
         internal enum WaitingStatus
         {
@@ -98,12 +99,12 @@ namespace NeonCapture.Objects
                     StatusText.i.SetStatus($"Auto-save in {(int)endingTimer + 1}...");
             }
 
-            if (recordStatus == RecordStatus.RecordRecieved)
+            if (recordStatus == RecordStatus.RecordRecieved && !nudgeSent)
             {
                 recordTimer -= Time.unscaledDeltaTime;
                 if (recordTimer <= 0)
                 {
-                    recordTimer = .05f;
+                    nudgeSent = true;
                     SendStartRecord();
                 }
             }
@@ -164,6 +165,8 @@ namespace NeonCapture.Objects
 
         public void SendStartRecord()
         {
+            recordStatus = RecordStatus.RecordSent;
+            recordTimer = .05f;
             if (Settings.StallLoad.Value)
                 Hooks.showWaiting = true;
             else
@@ -277,6 +280,7 @@ namespace NeonCapture.Objects
             usedBonus = null;
 
             endingTimer = 0;
+            nudgeSent = false;
             recordStatus = RecordStatus.Stopping;
             waitingStatus = WaitingStatus.Save;
             dontSave = false;
@@ -478,7 +482,6 @@ namespace NeonCapture.Objects
                                     }
 
                                     recordStatus = RecordStatus.RecordRecieved;
-                                    recordTimer = .05f;
                                     return;
                                 }
                             case "StopRecord":


### PR DESCRIPTION
## Initial Bug
Periodically when resetting a level in Neon White, the game would hang indefinitely at the loading screen. The mod was waiting for OBS to confirm a new recording had started, but that confirmation never arrived, blocking the level from loading.

## Root Cause
OBS has a quirk on recording restarts: after receiving a `StartRecord` request, it responds with `100` (success) immediately but does not actually begin the output. It requires a second `StartRecord` request sent ~50ms later to trigger the real startup and broadcast the `OBS_WEBSOCKET_OUTPUT_STARTING` event.

The original code handled this correctly via a retry timer in Update(), but the timer was tied to the `RecordRecieved` state — meaning every time a `StartRecord` response arrived, it reset the timer and re-armed the retry. This created an infinite retry loop: if `STARTING` ever failed to arrive (because a request was lost or OBS was temporarily unresponsive), the game would keep sending `StartRecord` requests every 50ms forever, each response resetting the timer and preventing the loop from ever exiting.

The original hang occurred when the second `StartRecord` request was sent but silently failed to reach OBS — the game then spun indefinitely in `RecordRecieved` state, retrying but never getting `STARTING`.

## The Fix
Three changes to [Handler.cs](Objects/Handler.cs):

`SendStartRecord()` now sets `recordStatus = RecordSent` and arms `recordTimer = 0.05f` at the moment of sending, so the retry countdown begins from the send rather than the response.

`Update()` fires the retry only when `recordStatus == RecordRecieved && !nudgeSent`. The new `nudgeSent` flag ensures exactly one nudge is sent per cycle — enough to satisfy OBS's startup requirement, but no infinite loop if `STARTING` is delayed.

`SetStopping()` resets `nudgeSent = false` each time a stop is initiated, so every new restart cycle gets its one nudge slot.

The net effect: each restart sends the initial `StartRecord`, waits for the response, then sends one nudge ~50ms later (which OBS needs to actually start), and stops there regardless of what happens next.